### PR TITLE
Correctly spell Canio

### DIFF
--- a/worlds/balatro/Items.py
+++ b/worlds/balatro/Items.py
@@ -179,7 +179,7 @@ item_table: Dict[str, ItemData] = {
     "Astronomer": ItemData(offset + 158),
     "Burnt Joker": ItemData(offset + 159),
     "Bootstraps": ItemData(offset + 160),
-    "Caino": ItemData(offset + 161),
+    "Canio": ItemData(offset + 161),
     "Triboulet": ItemData(offset + 162),
     "Yorick": ItemData(offset + 163),
     "Chicot": ItemData(offset + 164),


### PR DESCRIPTION
It's spelled Canio, not Caino. I'm aware it's internally called `j_caino`.
![image](https://github.com/user-attachments/assets/06059165-ff29-4e40-969c-da8441174490)
